### PR TITLE
Bump TypeScript target js version

### DIFF
--- a/Server/tsconfig.json
+++ b/Server/tsconfig.json
@@ -1,6 +1,7 @@
 {
 	"compilerOptions": {
-		"target": "es2016" /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */,
+		"target": "es2022" /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */,
+		"lib": ["ES2022"],
 		"module": "commonjs" /* Specify what module code is generated. */,
 		"rootDir": "./src" /* Specify the root folder within your source files. */,
 		"outDir": "./build" /* Specify an output folder for all emitted files. */,

--- a/Website/tsconfig.json
+++ b/Website/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es2022",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,


### PR DESCRIPTION
Our current typescript config still targets es2016, with worse support for async/await. For example this causes stack-trackes like these (these are simulated errors):

~~~
Error
    at Function.<anonymous> (<...>/RailTrail/Server/src/services/vehicle.service.ts:236:13)
    at Generator.next (<anonymous>)
    at <...>/RailTrail/Server/src/services/vehicle.service.ts:31:71
    at new Promise (<anonymous>)
    at __awaiter (<...>/RailTrail/Server/src/services/vehicle.service.ts:27:12)
    at Function.getVehiclePosition (<...>/RailTrail/Server/src/services/vehicle.service.ts:244:16)
    at Function.<anonymous> (<...>/RailTrail/Server/src/services/vehicle.service.ts:299:38)
    at Generator.next (<anonymous>)
    at <...>/RailTrail/Server/src/services/vehicle.service.ts:31:71
    at new Promise (<anonymous>)
~~~

with a newer JS target, these stacktraces become much more helpful:

~~~
Error
    at Function.getVehiclePosition (<...>/RailTrail/Server/src/services/vehicle.service.ts:236:13)
    at Function.getCurrentTrackForVehicle (<...>/RailTrail/Server/src/services/vehicle.service.ts:268:39)
    at <...>/RailTrail/Server/src/services/vehicle.service.ts:213:46
    at Array.filter (<anonymous>)
    at Function.getAllVehiclesForTrack (<...>/RailTrail/Server/src/services/vehicle.service.ts:212:12)
    at async Function.getNearbyVehicles (<...>/RailTrail/Server/src/services/vehicle.service.ts:133:28)
    at async updateVehicleApp (<...>/RailTrail/Server/src/routes/vehicle.route.ts:360:44)
~~~

There might also be a small performace benefit from this, however I am not sure

The specific values chosen in this PR are recommended for node 18 by https://github.com/microsoft/TypeScript/wiki/Node-Target-Mapping