### PR TITLE
128 [Backend] Refinenment of Deletion for Vehicles, VehicleTypes and POIs

### DIFF
--- a/Server/prisma/schema.prisma
+++ b/Server/prisma/schema.prisma
@@ -35,7 +35,7 @@ model POI {
     isTurningPoint  Boolean
 
     typeId          Int
-    type            POIType @relation(fields: [typeId], references: [uid])
+    type            POIType @relation(fields: [typeId], references: [uid], onDelete: Cascade)
     trackId         Int
     track           Track @relation(fields: [trackId], references: [uid], onDelete: Cascade)
 }

--- a/Server/prisma/schema.prisma
+++ b/Server/prisma/schema.prisma
@@ -72,8 +72,6 @@ model Vehicle {
     logs        Log[]
 
     inactive    Boolean @default(false)
-
-    @@unique([name, trackId])
 }
 
 model Tracker {

--- a/Server/prisma/schema.prisma
+++ b/Server/prisma/schema.prisma
@@ -71,6 +71,8 @@ model Vehicle {
     tracker     Tracker[]
     logs        Log[]
 
+    inactive    Boolean @default(false)
+
     @@unique([name, trackId])
 }
 

--- a/Server/prisma/schema.prisma
+++ b/Server/prisma/schema.prisma
@@ -57,6 +57,8 @@ model VehicleType {
     description String?
 
     vehicle     Vehicle[]
+
+    inactive Boolean @default(false)
 }
 
 model Vehicle {

--- a/Server/prisma/schema.prisma
+++ b/Server/prisma/schema.prisma
@@ -52,7 +52,7 @@ model Track {
 
 model VehicleType {
     uid         Int @id @default(autoincrement())
-    name        String @unique
+    name        String
     icon        String
     description String?
 

--- a/Server/src/services/db/vehicle.controller.ts
+++ b/Server/src/services/db/vehicle.controller.ts
@@ -132,8 +132,7 @@ export default class VehicleController {
 
 		// Due to soft-deletion we need to check if a vehicle with said name alread exists in the active state
 		if (args.inactive == false) {
-			let veh = await this.getByName(args.name, args.trackId)
-			if (veh == null) {
+			if ((await this.getByName(args.name, args.trackId)) == null) {
 				// Vehicle doesn't exists in active state
 				return await this.prisma.vehicle.create({
 					data: args
@@ -195,7 +194,7 @@ export default class VehicleController {
 	 */
 	public async remove(uid: number): Promise<boolean> {
 		// Remove tracker ref to vehicle
-		let veh = await this.prisma.tracker.updateMany({
+		await this.prisma.tracker.updateMany({
 			where: {
 				vehicleId: uid
 			},
@@ -222,7 +221,8 @@ export default class VehicleController {
 	public async getAll(trackId?: number, inactive: boolean = false): Promise<Vehicle[]> {
 		return await this.prisma.vehicle.findMany({
 			where: {
-				trackId: trackId
+				trackId: trackId,
+				inactive: inactive
 			},
 			include: {
 				type: true,

--- a/Server/src/services/db/vehicle.controller.ts
+++ b/Server/src/services/db/vehicle.controller.ts
@@ -34,13 +34,14 @@ export default class VehicleController {
 	 * @param name - **unique** Name for the type of vehicle.
 	 * @param icon - unique icon name for visualization
 	 * @param description - optional description for the type.
+	 * @param inactive - indicator of current status (Default: False)
 	 * @returns VehicleType | null if an error occurs
 	 */
 	public async saveType(args: Prisma.VehicleTypeCreateInput): Promise<VehicleType> {
 		// Due to soft-deletion we need to check if a type already exists in an active state
 		if (args.inactive == false) {
 			if ((await this.getTypeByName(args.name)) == null) {
-				// Vehicle doesn't exists in active state
+				// VehicleType doesn't exists in active state
 				return await this.prisma.vehicleType.create({
 					data: args
 				})
@@ -70,7 +71,9 @@ export default class VehicleController {
 	 * The parameter are given via object deconstruction from the model `VehicleType`!
 	 * Currently given parameters are:
 	 * @param name - New name of the vehicle type after change. (Optional)
+	 * @param icon - New icon of the vehicle type after change. (Optional)
 	 * @param description - New description of the vehicle type after change. (Optional)
+	 * @param inactive - New status of the vehicle type after change. (Optional)
 	 * @returns
 	 */
 	public async updateType(uid: number, args: Prisma.VehicleTypeUpdateInput): Promise<VehicleType> {
@@ -179,6 +182,7 @@ export default class VehicleController {
 	 * @param typeId - VehicleType uid
 	 * @param trackId - Track uid
 	 * @param name - display name for the given vehicle (Optional)
+	 * @param inactive - Status of the vehicle (Default: false)
 	 * @returns Vehicle
 	 */
 	public async save(args: Prisma.VehicleUncheckedCreateInput): Promise<Vehicle> {
@@ -219,6 +223,7 @@ export default class VehicleController {
 	 * @param typeId - New VehicleType.uid after change (Optional)
 	 * @param trackId - New Track.uid after change (Optional)
 	 * @param name - New display name after change (Optional)
+	 * @param inactive - New status of the vehicle type after change. (Optional)
 	 * @returns Vehicle
 	 */
 	public async update(uid: number, args: Prisma.VehicleUncheckedUpdateInput): Promise<Vehicle | null> {

--- a/Server/src/services/db/vehicle.controller.ts
+++ b/Server/src/services/db/vehicle.controller.ts
@@ -74,7 +74,7 @@ export default class VehicleController {
 	 * @returns
 	 */
 	public async updateType(uid: number, args: Prisma.VehicleTypeUpdateInput): Promise<VehicleType> {
-		if (args.inactive == true) {
+		if (args.inactive == false) {
 			// Operation tried to ressurrect type
 			throw new Prisma.PrismaClientKnownRequestError("Tried to ressurrect type.", {
 				code: "P2002",

--- a/Server/src/services/db/vehicle.controller.ts
+++ b/Server/src/services/db/vehicle.controller.ts
@@ -76,7 +76,7 @@ export default class VehicleController {
 	public async updateType(uid: number, args: Prisma.VehicleTypeUpdateInput): Promise<VehicleType> {
 		if (args.inactive == true) {
 			// Operation tried to ressurrect type
-			throw new Prisma.PrismaClientKnownRequestError("Type already exists in active state.", {
+			throw new Prisma.PrismaClientKnownRequestError("Tried to ressurrect type.", {
 				code: "P2002",
 				clientVersion: ""
 			})

--- a/Server/src/services/db/vehicle.controller.ts
+++ b/Server/src/services/db/vehicle.controller.ts
@@ -194,6 +194,17 @@ export default class VehicleController {
 	 * @returns True if the removal was successful. Otherwise throws an Error.
 	 */
 	public async remove(uid: number): Promise<boolean> {
+		// Remove tracker ref to vehicle
+		let veh = await this.prisma.tracker.updateMany({
+			where: {
+				vehicleId: uid
+			},
+			data: {
+				vehicleId: null
+			}
+		})
+
+		// Set vehicle status
 		await this.update(uid, { inactive: true })
 		return true
 	}


### PR DESCRIPTION
I refined the deletion in regards of the discussed soft deletes, soft cascading deletes and normal cascading deletes:

- POIs will now be deleted when the POIType gets deleted
- Vehicles will be set to an inactive state if they will be deleted
- VehicleTypes will be set to an inactive state as well and all connected vehicles will be set into an inactive state as well

Additionally I added logic to other methods for vehicle and vehicletypes as well
- `save` / `saveType` now checks if an already active Vehicle/VehicleType exists or if you are trying to create an already "inactive" object
- `update` / `updateType` doesnt allow for resurrecting any object
- some getters got inactive parameters that are default set to false. For example `getAll` now in default mode returns a list of all active entries but can be set to `inactive = true` for all inactive entries and `inactive = undefined` for all entries  regardless of status