### PR TITLE
Removed return await calls

### DIFF
--- a/Server/src/services/db/log.controller.ts
+++ b/Server/src/services/db/log.controller.ts
@@ -35,7 +35,7 @@ export default class LogController {
 	 */
 	public async save(args: Prisma.LogUncheckedCreateInput): Promise<Log> {
 		//LogUncheckCreateInput is used because of required relations with other models!
-		return await this.prisma.log.create({
+		return this.prisma.log.create({
 			data: args
 		})
 	}
@@ -58,7 +58,7 @@ export default class LogController {
 	 * @returns Log | null if an error occurs.
 	 */
 	public async update(uid: number, args: Prisma.LogUpdateInput): Promise<Log | null> {
-		return await this.prisma.log.update({
+		return this.prisma.log.update({
 			where: {
 				uid: uid
 			},
@@ -94,7 +94,7 @@ export default class LogController {
 	 * @returns Log[] - List of all logs
 	 */
 	public async getAll(vehicleId?: number, trackerId?: string, limit?: number): Promise<Log[]> {
-		return await this.prisma.log.findMany({
+		return this.prisma.log.findMany({
 			where: {
 				vehicleId: vehicleId,
 				trackerId: trackerId
@@ -116,7 +116,7 @@ export default class LogController {
 	 * @returns Log | null depending on if the log could be found.
 	 */
 	public async getLog(uid: number): Promise<Log | null> {
-		return await this.prisma.log.findUnique({
+		return this.prisma.log.findUnique({
 			where: {
 				uid: uid
 			},
@@ -140,7 +140,7 @@ export default class LogController {
 		// Earliest date which should be considered
 		const max_date = new Date(Date.now() - max_sec * 1000)
 
-		return await this.prisma.log.findMany({
+		return this.prisma.log.findMany({
 			where: {
 				vehicleId: vehicleId,
 				timestamp: {
@@ -163,7 +163,7 @@ export default class LogController {
 	 * @returns Log
 	 */
 	public async getLatestLog(vehicleId?: number, trackerId?: string): Promise<Log | null> {
-		return await this.prisma.log.findFirst({
+		return this.prisma.log.findFirst({
 			where: {
 				vehicleId: vehicleId,
 				trackerId: trackerId

--- a/Server/src/services/db/poi.controller.ts
+++ b/Server/src/services/db/poi.controller.ts
@@ -39,7 +39,7 @@ export default class POIController {
 	 * @returns POIType
 	 */
 	public async saveType(args: Prisma.POITypeCreateInput): Promise<POIType> {
-		return await this.prisma.pOIType.create({
+		return this.prisma.pOIType.create({
 			data: args
 		})
 	}
@@ -57,7 +57,7 @@ export default class POIController {
 	 * @returns POIType | null if an error occurs.
 	 */
 	public async updateType(uid: number, args: Prisma.POITypeUpdateInput): Promise<POIType | null> {
-		return await this.prisma.pOIType.update({
+		return this.prisma.pOIType.update({
 			where: {
 				uid: uid
 			},
@@ -86,7 +86,7 @@ export default class POIController {
 	 * @returns `POIType[]` - List of all types of poi.
 	 */
 	public async getAllTypes(): Promise<POIType[]> {
-		return await this.prisma.pOIType.findMany({})
+		return this.prisma.pOIType.findMany({})
 	}
 
 	/**
@@ -96,7 +96,7 @@ export default class POIController {
 	 * @returns POIType | null depending on if the type could be found.
 	 */
 	public async getTypeById(uid: number): Promise<POIType | null> {
-		return await this.prisma.pOIType.findUnique({
+		return this.prisma.pOIType.findUnique({
 			where: {
 				uid: uid
 			}
@@ -110,7 +110,7 @@ export default class POIController {
 	 * @returns POIType | null depending on if the type could be found.
 	 */
 	public async getTypeByName(name: string): Promise<POIType | null> {
-		return await this.prisma.pOIType.findUnique({
+		return this.prisma.pOIType.findUnique({
 			where: {
 				name: name
 			}
@@ -135,7 +135,7 @@ export default class POIController {
 	 */
 	public async save(args: Prisma.POIUncheckedCreateInput): Promise<POI> {
 		// POIUncheckCreateInput is used because of required relations based on the model!
-		return await this.prisma.pOI.create({
+		return this.prisma.pOI.create({
 			data: args
 		})
 	}
@@ -157,7 +157,7 @@ export default class POIController {
 	 */
 	public async update(uid: number, args: Prisma.POIUncheckedUpdateInput): Promise<POI> {
 		// POIUncheckUpdateInput is used because of required relations based on the model
-		return await this.prisma.pOI.update({
+		return this.prisma.pOI.update({
 			where: {
 				uid: uid
 			},
@@ -187,7 +187,7 @@ export default class POIController {
 	 * @returns POI[] - List of all pois. If an trackId was given: List of all pois on this specific track.
 	 */
 	public async getAll(trackId?: number): Promise<POI[]> {
-		return await this.prisma.pOI.findMany({
+		return this.prisma.pOI.findMany({
 			where: {
 				trackId: trackId
 			}
@@ -201,7 +201,7 @@ export default class POIController {
 	 * @returns POI | null depending on if the poi could be found.
 	 */
 	public async getById(uid: number): Promise<POI | null> {
-		return await this.prisma.pOI.findUnique({
+		return this.prisma.pOI.findUnique({
 			where: {
 				uid: uid
 			},
@@ -220,7 +220,7 @@ export default class POIController {
 	 * @returns POI[] - List of all pois with the given name. If an trackId was given: List of all pois on this specific track with the given name.
 	 */
 	public async getByName(name: string, trackId?: number): Promise<POI[]> {
-		return await this.prisma.pOI.findMany({
+		return this.prisma.pOI.findMany({
 			where: {
 				name: name,
 				trackId: trackId

--- a/Server/src/services/db/track.controller.ts
+++ b/Server/src/services/db/track.controller.ts
@@ -26,7 +26,7 @@ export default class TrackController {
 	 * @returns Track
 	 */
 	public async save(args: Prisma.TrackCreateInput): Promise<Track> {
-		return await this.prisma.track.create({
+		return this.prisma.track.create({
 			data: args
 		})
 	}
@@ -44,7 +44,7 @@ export default class TrackController {
 	 * @returns Track
 	 */
 	public async update(uid: number, args: Prisma.TrackUpdateInput): Promise<Track> {
-		return await this.prisma.track.update({
+		return this.prisma.track.update({
 			where: {
 				uid: uid
 			},

--- a/Server/src/services/db/tracker.controller.ts
+++ b/Server/src/services/db/tracker.controller.ts
@@ -27,7 +27,7 @@ export default class TrackerController {
 	 */
 	public async save(args: Prisma.TrackerUncheckedCreateInput): Promise<Tracker> {
 		//TrackerUncheckedCreateInput is used because of the relation to vehicles.
-		return await this.prisma.tracker.create({
+		return this.prisma.tracker.create({
 			data: args
 		})
 	}
@@ -45,7 +45,7 @@ export default class TrackerController {
 	 */
 	public async update(uid: string, args: Prisma.TrackerUncheckedUpdateInput): Promise<Tracker> {
 		//TrackerUncheckedUpdateInput is used because of the relation to vehicles.
-		return await this.prisma.tracker.update({
+		return this.prisma.tracker.update({
 			where: {
 				uid: uid
 			},
@@ -74,7 +74,7 @@ export default class TrackerController {
 	 * @returns Tracker[] - List of all trackers.
 	 */
 	public async getAll(): Promise<Tracker[]> {
-		return await this.prisma.tracker.findMany({})
+		return this.prisma.tracker.findMany({})
 	}
 
 	/**
@@ -84,7 +84,7 @@ export default class TrackerController {
 	 * @returns Tracker | null depending on if the tracker could be found.
 	 */
 	public async getById(uid: string): Promise<Tracker | null> {
-		return await this.prisma.tracker.findUnique({
+		return this.prisma.tracker.findUnique({
 			where: {
 				uid: uid
 			}
@@ -98,7 +98,7 @@ export default class TrackerController {
 	 * @returns List of trackers assigned to the vehicle.
 	 */
 	public async getByVehicleId(vehicleId: number): Promise<Tracker[]> {
-		return await this.prisma.tracker.findMany({
+		return this.prisma.tracker.findMany({
 			where: {
 				vehicleId: vehicleId
 			}

--- a/Server/src/services/db/user.controller.ts
+++ b/Server/src/services/db/user.controller.ts
@@ -24,7 +24,7 @@ export default class UserController {
 	 * @returns User
 	 */
 	public async save(args: Prisma.UserCreateInput): Promise<User> {
-		return await this.prisma.user.create({
+		return this.prisma.user.create({
 			data: args
 		})
 	}
@@ -41,7 +41,7 @@ export default class UserController {
 	 * @returns User
 	 */
 	public async update(name: string, args: Prisma.UserUpdateInput): Promise<User> {
-		return await this.prisma.user.update({
+		return this.prisma.user.update({
 			where: {
 				username: name
 			},
@@ -70,7 +70,7 @@ export default class UserController {
 	 * @returns `User[]` - List of all users.
 	 */
 	public async getAll(): Promise<User[]> {
-		return await this.prisma.user.findMany({})
+		return this.prisma.user.findMany({})
 	}
 
 	/**
@@ -80,7 +80,7 @@ export default class UserController {
 	 * @returns User | null depending on if the user could be found.
 	 */
 	public async getByUsername(username: string): Promise<User | null> {
-		return await this.prisma.user.findUnique({
+		return this.prisma.user.findUnique({
 			where: {
 				username: username
 			}

--- a/Server/src/services/db/vehicle.controller.ts
+++ b/Server/src/services/db/vehicle.controller.ts
@@ -42,7 +42,7 @@ export default class VehicleController {
 		if (args.inactive == false) {
 			if ((await this.getTypeByName(args.name)) == null) {
 				// VehicleType doesn't exists in active state
-				return await this.prisma.vehicleType.create({
+				return this.prisma.vehicleType.create({
 					data: args
 				})
 			} else {
@@ -84,7 +84,7 @@ export default class VehicleController {
 				clientVersion: ""
 			})
 		}
-		return await this.prisma.vehicleType.update({
+		return this.prisma.vehicleType.update({
 			where: {
 				uid: uid
 			},
@@ -130,7 +130,7 @@ export default class VehicleController {
 	 * @returns VehicleType[] - List of all vehicle types.
 	 */
 	public async getAllTypes(inactive: boolean = false): Promise<VehicleType[]> {
-		return await this.prisma.vehicleType.findMany({
+		return this.prisma.vehicleType.findMany({
 			where: {
 				inactive: inactive
 			}
@@ -144,7 +144,7 @@ export default class VehicleController {
 	 * @returns VehicleType | null depending on if the vehicle type could be found.
 	 */
 	public async getTypeById(uid: number): Promise<VehicleType | null> {
-		return await this.prisma.vehicleType.findUnique({
+		return this.prisma.vehicleType.findUnique({
 			where: {
 				uid: uid
 			}
@@ -163,7 +163,7 @@ export default class VehicleController {
 	 */
 	public async getTypeByName(name: string, inactive: boolean = false): Promise<VehicleType | null> {
 		// Due to Soft-Deletion multiple inactive entries can exist with the same name
-		return await this.prisma.vehicleType.findFirst({
+		return this.prisma.vehicleType.findFirst({
 			where: {
 				name: name,
 				inactive: inactive
@@ -192,7 +192,7 @@ export default class VehicleController {
 		if (args.inactive == false) {
 			if ((await this.getByName(args.name, args.trackId)) == null) {
 				// Vehicle doesn't exists in active state
-				return await this.prisma.vehicle.create({
+				return this.prisma.vehicle.create({
 					data: args
 				})
 			} else {
@@ -235,7 +235,7 @@ export default class VehicleController {
 				clientVersion: ""
 			})
 		}
-		return await this.prisma.vehicle.update({
+		return this.prisma.vehicle.update({
 			where: {
 				uid: uid
 			},
@@ -278,7 +278,7 @@ export default class VehicleController {
 	 * @returns Vehicle[]
 	 */
 	public async getAll(trackId?: number, inactive: boolean = false): Promise<Vehicle[]> {
-		return await this.prisma.vehicle.findMany({
+		return this.prisma.vehicle.findMany({
 			where: {
 				trackId: trackId,
 				inactive: inactive
@@ -297,7 +297,7 @@ export default class VehicleController {
 	 * @returns Vehicle | null depending on if the vehicle could be found.
 	 */
 	public async getById(uid: number): Promise<Vehicle | null> {
-		return await this.prisma.vehicle.findUnique({
+		return this.prisma.vehicle.findUnique({
 			where: {
 				uid: uid
 			},
@@ -319,7 +319,7 @@ export default class VehicleController {
 	public async getByName(name: string, trackId: number, inactive: boolean = false): Promise<Vehicle | null> {
 		// Due to Soft-Deletion we can't convert name and trackId to a key anymore because we can have
 		// Multiple inactive vehicles with the same name but only one active vehicle with this name on the track
-		return await this.prisma.vehicle.findFirst({
+		return this.prisma.vehicle.findFirst({
 			where: {
 				name: name,
 				trackId: trackId,


### PR DESCRIPTION
When a function is async, it automatically returns the return type wrapped into a Promise. If we make a database call, the return type is a Promise that contains the data. Unwrapping this before directly wrapping it back again into a Promise in the execution of the return statement is just unnecessary and might add some more overhead for the database calls, as this Unwrapping (the database call) - Wrapping (with the return call) - Unwrapping (in the calling function) might add a little overhead.